### PR TITLE
Add DB support and FastAPI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Forge Ops is a command-line application designed to help developers manage softw
     *   Task lists are stored in JSON files under the `task_lists/` directory.
         *   Task lists are stored as JSON files in the `task_lists/` directory. Each JSON file includes metadata like version, name, association (issue, project, personal), creator, creation date, and a list of tasks. Each task has a unique ID, subject, description, status, creation date, priority, and a list of comments with timestamps.
 *   **Command-Line Interface:** Easy-to-use CLI for all functionalities.
+*   **SQLite Storage:** Issues and repositories are replicated into a local SQLite database for easy querying.
+*   **FastAPI Service:** A minimal API exposes the issues at `/issues`.
 
 ## Setup and Installation
 
@@ -42,7 +44,7 @@ Follow these steps to set up the Forge Ops Issue Tracker on your local machine:
     ```bash
     uv pip sync
     ```
-    *This command will install dependencies based on `uv.lock` if present, or `pyproject.toml`.*
+    *This command installs dependencies (including FastAPI and uvicorn) based on `uv.lock` or `pyproject.toml`.*
 
 ## Usage
 
@@ -139,6 +141,14 @@ python main.py <command> [options]
     python main.py add-repo my-new-project
     ```
 
+*   **Migrate existing issues into the database:**
+    ```bash
+    uv run python main.py migrate-issues
+    ```
+
+This command reads all JSON files in the `issues/` folder and inserts them into `forgeops.db`.
+
+
 **Help:**
 
 *   **Show help information:**
@@ -149,6 +159,16 @@ python main.py <command> [options]
     python main.py help
     ```
     *(Also available via `python main.py --help` or `python main.py -h`)*
+
+### Running the API
+
+Start the FastAPI service with uvicorn:
+
+```bash
+uvicorn api:app --reload
+```
+
+Once running, navigate to `http://localhost:8000/issues` to see all issues in the database.
 
 ## Project Structure
 

--- a/api.py
+++ b/api.py
@@ -1,0 +1,12 @@
+from fastapi import FastAPI
+from core.db import Database
+
+app = FastAPI(title="ForgeOps Issue API")
+
+db = Database()
+
+
+@app.get("/issues")
+def list_issues():
+    """Return all issues stored in the database."""
+    return db.get_issues()

--- a/commands/create_issue.py
+++ b/commands/create_issue.py
@@ -6,6 +6,7 @@ import sys
 from datetime import datetime
 
 from core.issue_tracker import IssueTracker
+from core.db import Database
 
 
 def create_issue():
@@ -53,6 +54,8 @@ def create_issue():
         confirm = input("\nCreate this issue? (Y/n): ").strip().lower()
         if confirm in ['', 'y', 'yes']:
             issue_file = tracker.file_manager.save_issue(issue_data)
+            Database().add_issue(issue_data)
+            tracker.repo_manager.db.add_repository(repo_name)
             print(f"\n✅ Issue {issue_id} created successfully!")
             print(f"📁 Saved to: {issue_file}")
         else:

--- a/commands/migrate_issues.py
+++ b/commands/migrate_issues.py
@@ -1,0 +1,17 @@
+"""Migrate existing issue JSON files into the SQLite database."""
+
+from core.file_manager import FileManager
+from core.db import Database
+
+
+def migrate_issues() -> None:
+    fm = FileManager()
+    db = Database()
+    issues = fm.load_all_issues()
+    if not issues:
+        print("No issues found to migrate.")
+        return
+    for issue in issues:
+        db.add_issue(issue)
+        db.add_repository(issue["repository"])
+    print(f"Migrated {len(issues)} issue(s) into {db.db_path}.")

--- a/core/db.py
+++ b/core/db.py
@@ -1,0 +1,72 @@
+import sqlite3
+from pathlib import Path
+from typing import List, Dict
+
+
+class Database:
+    """Simple SQLite wrapper for issues and repositories."""
+
+    def __init__(self, db_path: str = "forgeops.db") -> None:
+        self.db_path = Path(db_path)
+        self.conn = sqlite3.connect(self.db_path)
+        self.conn.row_factory = sqlite3.Row
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS repositories (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS issues (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                description TEXT,
+                repository TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY(repository) REFERENCES repositories(name)
+            )
+            """
+        )
+        self.conn.commit()
+
+    def add_repository(self, name: str) -> None:
+        cur = self.conn.cursor()
+        cur.execute("INSERT OR IGNORE INTO repositories(name) VALUES (?)", (name,))
+        self.conn.commit()
+
+    def get_repositories(self) -> List[str]:
+        cur = self.conn.cursor()
+        cur.execute("SELECT name FROM repositories ORDER BY name")
+        return [row[0] for row in cur.fetchall()]
+
+    def add_issue(self, issue_data: Dict[str, str]) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            INSERT OR REPLACE INTO issues (id, title, description, repository, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                issue_data["id"],
+                issue_data["title"],
+                issue_data.get("description"),
+                issue_data["repository"],
+                issue_data["created_at"],
+            ),
+        )
+        self.conn.commit()
+
+    def get_issues(self) -> List[Dict[str, str]]:
+        cur = self.conn.cursor()
+        cur.execute("SELECT id, title, description, repository, created_at FROM issues ORDER BY id")
+        return [dict(row) for row in cur.fetchall()]
+
+    def close(self) -> None:
+        self.conn.close()

--- a/core/repository_manager.py
+++ b/core/repository_manager.py
@@ -6,10 +6,13 @@ import json
 import re
 from pathlib import Path
 
+from core.db import Database
+
 
 class RepositoryManager:
-    def __init__(self, repos_file="repos.json"):
+    def __init__(self, repos_file: str = "repos.json", db_path: str = "forgeops.db"):
         self.repos_file = Path(repos_file)
+        self.db = Database(db_path)
         self._init_repos_registry()
     
     def _init_repos_registry(self):
@@ -17,20 +20,26 @@ class RepositoryManager:
         if not self.repos_file.exists():
             default_repos = [
                 "jules-dev-kit",
-                "my-app", 
+                "my-app",
                 "backend-api",
                 "frontend-web",
                 "mobile-app"
             ]
             with open(self.repos_file, 'w') as f:
                 json.dump({"repositories": default_repos}, f, indent=2)
+
+            for repo in default_repos:
+                self.db.add_repository(repo)
     
     def load_repositories(self):
         """Load the list of known repositories."""
         try:
             with open(self.repos_file, 'r') as f:
                 data = json.load(f)
-                return data.get("repositories", [])
+                repos = data.get("repositories", [])
+                for repo in repos:
+                    self.db.add_repository(repo)
+                return repos
         except (FileNotFoundError, json.JSONDecodeError) as e:
             print(f"Error loading repositories: {e}")
             return []
@@ -74,8 +83,9 @@ class RepositoryManager:
         if repo_name not in repos:
             repos.append(repo_name)
             repos.sort()  # Keep them sorted
-            
+
             with open(self.repos_file, 'w') as f:
                 json.dump({"repositories": repos}, f, indent=2)
+            self.db.add_repository(repo_name)
             return True
         return False

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from commands.list_issues import list_issues
 from commands.view_issue import view_issue
 from commands.list_repos import list_repos
 from commands.add_repo import add_repo
+from commands.migrate_issues import migrate_issues
 
 
 def show_help():
@@ -29,6 +30,8 @@ def show_help():
     print("\nRepository Management:")
     print("  python main.py list-repos                List all registered repositories")
     print("  python main.py add-repo <repo-name>      Add a new repository to registry")
+    print("\nDatabase:")
+    print("  python main.py migrate-issues            Import issue files into SQLite")
     print("\nExamples:")
     print("  python main.py create-issue")
     print("  python main.py list-issues")
@@ -82,16 +85,19 @@ def main():
                 print("Usage: python main.py add-repo <repo-name>")
                 print("Example: python main.py add-repo my-new-project")
                 sys.exit(1)
-            
+
             repo_name = sys.argv[2]
             add_repo(repo_name)
-        
+
+        elif command == "migrate-issues":
+            migrate_issues()
+
         elif command in ["help", "--help", "-h"]:
             show_help()
         
         else:
             print(f"Unknown command: {command}")
-            print("Available commands: create-issue, list-issues, view-issue, list-repos, add-repo")
+            print("Available commands: create-issue, list-issues, view-issue, list-repos, add-repo, migrate-issues")
             print("Use 'python main.py help' for more information.")
             sys.exit(1)
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,7 @@ version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
-dependencies = []
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]"
+]

--- a/uv.lock
+++ b/uv.lock
@@ -6,3 +6,11 @@ requires-python = ">=3.13"
 name = "jules-dev-kit"
 version = "0.1.0"
 source = { virtual = "." }
+
+[[package]]
+name = "fastapi"
+version = "0.116.1"
+
+[[package]]
+name = "uvicorn"
+version = "0.29.0"


### PR DESCRIPTION
## Summary
- track repos and issues in a new SQLite database
- store new issues in the database when created
- migrate existing issue JSON files to the DB
- expose issues through a minimal FastAPI app
- document database usage and API instructions
- add FastAPI and uvicorn dependencies

## Testing
- `pip install fastapi uvicorn`
- `pip install datetime_truncate`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c02d87680832d9c48a9ed471e8a7d